### PR TITLE
added: insecure mode and debuging for kvlt, CLI params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ installed into the root of the repository.
 $ npm install websocket
 $ npm install eventsource
 $ npm install xhr2
+$ npm install request
 ```
 
 When this is complete, you can run the application with:

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,9 @@
   :url "https://github.com/loomis/node-cljs-test.git"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.89"]
-                 [io.nervous/kvlt "0.1.1"]
+                 [org.clojure/tools.cli "0.3.5"]
+                 [io.nervous/kvlt "0.1.3-SNAPSHOT"]
+                 [com.taoensso/timbre "4.5.0"]
                  [org.clojure/core.async "0.2.385"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
   :plugins [[lein-npm "0.6.1"]

--- a/src/nct/core.cljs
+++ b/src/nct/core.cljs
@@ -2,20 +2,51 @@
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require
    [clojure.browser.repl :as repl]
+   [cljs.tools.cli :refer [parse-opts]]
+   [cljs.nodejs :as node]
    [kvlt.chan :as chan]
+   [taoensso.timbre :as log]
    [cljs.core.async :refer [chan >!]]))
 
-;; (defonce conn
-;;   (repl/connect "http://localhost:9000/repl"))
+(def default-url "https://httpbin.org/get")
+
+(def cli-options
+  [
+   ["-i" "--insecure" "Insecure connection"]
+   ["-u" "--url URL" "URL to connect to" :default default-url]
+   ["-d" "--debug" "Debug output"]
+   ["-h" "--help"]
+   ])
+
+(defn usage [options-summary]
+  (str "Usage: program-name [options]\n"
+       "Options:\n"
+       options-summary))
+
+(defn exit [status msg]
+    (println msg)
+    (.exit node/process status))
+
+(defn parse-args
+  [args]
+  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    (cond
+      (:help options) (exit 0 (usage summary))
+      errors (exit 1 errors))
+    (if (:debug options)
+      (log/set-level! :debug))
+    {:options options :arguments arguments}))
 
 (enable-console-print!)
-(println "Hello world!")
 
 (defn -main [& args]
-  (go
-   (let [url "https://google.com/"
-         {:keys [status]} (<! (kvlt.chan/request! {:url url}))]
-         (println "STATUS: " status)))
-  (println "Hello world main!"))
+  (let [{:keys [options arguments]} (parse-args args)]
+    (go
+     (let [{:keys [status] :as r} (<! (kvlt.chan/request! {:method :get
+                                                           :url (:url options)
+                                                           :kvlt.platform/insecure? (:insecure options)}))]
+      (if status
+        (println "STATUS: " status)
+        (println "ERROR: " r))))))
 
 (set! *main-cli-fn* -main)


### PR DESCRIPTION
Changes:

- `npm install request`
- kvlt "0.1.3-SNAPSHOT" (temporarily SNAPSHOT - Moe promised to release by the end of the week)
- experimented a bit with `cljs.tools.cli` and `cljs.nodejs` namespaces
- changing logging to debug mode in kvlt doesn't work at the moment. Will be fixed by Moe and available in 0.1.3 release.